### PR TITLE
Fix Robot Control section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -70,7 +70,7 @@ ways that make it available to all.
    course/measuring_distance/parking_garage
 
 
-   .. toctree:: 
+.. toctree:: 
    :maxdepth: 1
    :hidden:
    :caption: Robot Control


### PR DESCRIPTION
The `toctree` directive was not correctly indented for this section which meant it did not render correctly in the sidebar.